### PR TITLE
Change boost logic to cleaner version

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -8,7 +8,7 @@
 
 
 constexpr double thresh = 0.2;
-constexpr double boostMult = 1.5;
+constexpr double boostMult = 0.5;
 
 
 RobotContainer::RobotContainer() : m_controller{0} {
@@ -29,7 +29,7 @@ RobotContainer::RobotContainer() : m_controller{0} {
         double rightX = Deadband(m_controller.GetRawAxis(static_cast<int>(frc::XboxController::Axis::kRightX)), thresh); //right stick, left/right
         bool leftBumper = m_controller.GetRawButton((static_cast<int>(frc::XboxController::Button::kLeftBumper))); //left bumper, boost
         
-        if (leftBumper) {
+        if (!leftBumper) {
           leftY *= boostMult;
           rightX *= boostMult;
         }

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -26,6 +26,8 @@ class RobotContainer {
 
  private:
   // The robot's subsystems and commands are defined here...
+  // Controller for robot
+  frc::XboxController m_controller;
   DriveSubsystem m_drive;
   // The arm subsystem
   FaceSmasherSubsystem m_arm;


### PR DESCRIPTION
Changes logic for boost by scaling *down* rather than up, which keeps all values on [-1,1]. Also fixed build error with the `frc::XboxController` object getting deleted